### PR TITLE
Some icky string munging

### DIFF
--- a/lib/abalone.rb
+++ b/lib/abalone.rb
@@ -46,10 +46,15 @@ class Abalone < Sinatra::Base
           # there must be some form of event driven pty interaction, EM or some gem maybe?
           reader.sync = true
           @term = Thread.new do
+            carry = []
             loop do
               begin
                 PTY.check(@pid, true)
-                data = reader.read_nonblock(512) # we read non-blocking to stream data as quickly as we can
+                output = reader.read_nonblock(512).unpack('c*') # we read non-blocking to stream data as quickly as we can
+                index = output.rindex { |x| x < 128 } # find the last low bit
+                carry = output[index...-11]           # save the any remaining high bits and partial chars for next go-round
+                data  = (carry + output[0..index]).pack('c*').force_encoding('UTF-8') # and pack the rest back into a string to send
+
                 ws.send(data)
 
               rescue IO::WaitReadable


### PR DESCRIPTION
So, since we're reading bytes from the process descriptor, sometimes the
read will split in the MIDDLE of a UTF8 wide character. This makes the
resulting string invalid, meaning that any string processing on it will
raise an exception. We can't just drop invalid characters, because that
means that random high characters all over get missed.

Instead, I keep a `carry` array of bytes. I find the last low bit in the
command output string, since that's the last one I _know_ is valid and
split the string right there. The trailing bytes are saved in `carry`
and the rest is re-encoded as a UTF8 string and pumped back to the
client.

I'd much rather just stuff it into the websocket and let the hterm
client reassemble it, but apparently the `ws.send()` does some string
processing and that barfs on the invalid bytes.

@adrienthebo tell me a better way, yo!
