### PR TITLE
Support sticky sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /.config
 /coverage/
 /InstalledFiles
-/pkg/
+/binford2k-abalone/pkg/
 /spec/reports/
 /spec/examples.txt
 /test/tmp/

--- a/binford2k-abalone/manifests/config.pp
+++ b/binford2k-abalone/manifests/config.pp
@@ -11,6 +11,7 @@ class abalone::config {
   $ssh_user    = $abalone::ssh_user
   $command     = $abalone::command
   $params      = $abalone::params
+  $uuid        = $abalone::uuid
 
   File {
     owner  => 'root',

--- a/binford2k-abalone/manifests/init.pp
+++ b/binford2k-abalone/manifests/init.pp
@@ -11,6 +11,7 @@ class abalone (
   $ssh_user    = $abalone::params::ssh_user,
   $command     = $abalone::params::command,
   $params      = $abalone::params::params,
+  $uuid        = $abalone::params::uuid,
 ) inherits abalone::params {
   # TODO: parameter validation
 

--- a/binford2k-abalone/manifests/params.pp
+++ b/binford2k-abalone/manifests/params.pp
@@ -10,4 +10,5 @@ class abalone::params {
   $ssh_user   = undef
   $command    = undef
   $params     = undef
+  $uuid       = false
 }

--- a/binford2k-abalone/templates/config.yaml.erb
+++ b/binford2k-abalone/templates/config.yaml.erb
@@ -21,6 +21,9 @@
 <% if @bannerfile -%>
 :bannerfile: <%= @bannerfile %>
 <% end %>
+<% if @uuid -%>
+:uuid: true
+<% end -%>
 <% if @params -%>
 :params:
 <% if @params.class == Hash -%>

--- a/lib/abalone.rb
+++ b/lib/abalone.rb
@@ -5,6 +5,7 @@ require 'sinatra-websocket'
 
 require 'pty'
 require 'io/console'
+require 'securerandom'
 
 class Abalone < Sinatra::Base
   set :logging, true
@@ -12,6 +13,8 @@ class Abalone < Sinatra::Base
   set :protection, :except => :frame_options
   set :public_folder, "#{settings.root}/../public"
   set :views, "#{settings.root}/../views"
+
+  enable :sessions
 
   before {
     env["rack.logger"] = settings.logger if settings.logger
@@ -25,6 +28,11 @@ class Abalone < Sinatra::Base
   }
 
   get '/?:user?' do
+
+    if settings.uuid
+      session[:uuid] ||= SecureRandom.uuid
+    end
+
     if !request.websocket?
       #redirect '/index.html'
       @requestUsername = (settings.respond_to?(:ssh) and ! settings.ssh.include?(:user)) rescue false
@@ -205,6 +213,8 @@ class Abalone < Sinatra::Base
             command << value
           end
         end
+
+        command << "--uuid" << session[:uuid] if settings.uuid
 
         return command
       end


### PR DESCRIPTION
Adds a boolean parameter of "uuid" which will enable setting a uuid in a
cookie. This is passed along as a --uuid flag to the command on the
backend.