### PR TITLE
Remove $path variable

### DIFF
--- a/binford2k-abalone/manifests/init.pp
+++ b/binford2k-abalone/manifests/init.pp
@@ -2,7 +2,6 @@ class abalone (
   $port        = $abalone::params::port,
   $bind        = $abalone::params::bind,
   $method      = $abalone::params::method,
-  $path        = $abalone::params::path,
   $bannerfile  = $abalone::params::bannerfile,
   $logfile     = $abalone::params::logfile,
   $ssh_host    = $abalone::params::ssh_host,


### PR DESCRIPTION
$path = $abalone::params::path does not exist in params, updated so rspec can pass.